### PR TITLE
fixing fileupload

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -3,7 +3,7 @@
 jupyter nbextension     enable --py --sys-prefix appmode
 jupyter serverextension enable --py --sys-prefix appmode
 jupyter serverextension enable --py nbserverproxy
-jupyter nbextension install --py fileupload
-jupyter nbextension enable --py fileupload
+jupyter nbextension install --py --user fileupload
+jupyter nbextension enable --py --user fileupload
 
 cd sample_data; unzip -q low_res.zip; cd ..

--- a/data_uploader.ipynb
+++ b/data_uploader.ipynb
@@ -1,46 +1,197 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Overview\n",
+    "The tool serves to let you create task files from CSVs and zip files that you upload through the browser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/srv/conda/lib/python3.6/importlib/_bootstrap.py:219: RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88\n",
+      "  return f(*args, **kwds)\n",
+      "/srv/conda/lib/python3.6/importlib/_bootstrap.py:219: RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88\n",
+      "  return f(*args, **kwds)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ipywidgets as ipw\n",
+    "import pandas as pd\n",
+    "import json, io, os, tempfile\n",
+    "import fileupload as fu\n",
+    "from IPython.display import display, FileLink\n",
+    "\n",
+    "def upload_as_file_widget(callback=None):\n",
+    "    \"\"\"Create an upload files button that creates a temporary file and calls a function with the path.\n",
+    "    \"\"\"\n",
+    "    _upload_widget = fu.FileUploadWidget()\n",
+    "    \n",
+    "    def _virtual_file(change):\n",
+    "        file_ext = os.path.splitext(change['owner'].filename)[-1]\n",
+    "        print('Uploaded `{}`'.format(change['owner'].filename))\n",
+    "        if callback is not None:\n",
+    "            with tempfile.NamedTemporaryFile(suffix=file_ext) as f:\n",
+    "                f.write(change['owner'].data)\n",
+    "                callback(f.name)\n",
+    "\n",
+    "    _upload_widget.observe(_virtual_file, names='data')\n",
+    "    \n",
+    "    return _upload_widget\n",
+    "def make_task(in_df, \n",
+    "              image_path='Image Index', \n",
+    "              output_labels='Finding Labels', \n",
+    "              base_image_directory = 'sample_data'):\n",
+    "    return {\n",
+    "        'google_forms': {'form_url': 'https://docs.google.com/forms/d/e/1FAIpQLSfBmvqCVeDA7IZP2_mw_HZ0OTgDk2a0JN4VlY5KScECWC-_yw/viewform', \n",
+    "        'sheet_url': 'https://docs.google.com/spreadsheets/d/1T02tRhe3IUUHYsMchc7hmH8nVI3uR0GffdX1PNxKIZA/edit?usp=sharing'\n",
+    "                },\n",
+    "        'dataset': {\n",
+    "            'image_path': image_path, # column name\n",
+    "            'output_labels': output_labels, # column name\n",
+    "            'dataframe': in_df.to_dict(),\n",
+    "            'base_image_directory': base_image_directory # path\n",
+    "        }\n",
+    "    }\n",
+    "def save_task(annotation_task, out_path='task.json'):\n",
+    "    with open(out_path, 'w') as f:\n",
+    "        json.dump(annotation_task, f)\n",
+    "    return out_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instructions\n",
+    "Load a CSV file and select the columns for the image path, labels and the name of the directory where the images are located"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ipywidgets as ipw\n",
-    "import pandas as pd\n",
-    "import json"
+    "def _load_csv_app(in_path):\n",
+    "    \"\"\"\n",
+    "    A callback to create an app from an uploaded CSV file\n",
+    "    >>> _load_csv_app('sample_data/dataset_overview.csv')\n",
+    "    \"\"\"\n",
+    "    ds_df = pd.read_csv(in_path)\n",
+    "    table_viewer = ipw.HTML(value=ds_df.sample(3).T.to_html(), layout = ipw.Layout(width=\"45%\"))\n",
+    "    image_path_widget = ipw.Dropdown(\n",
+    "        options=ds_df.columns,\n",
+    "        value=ds_df.columns[0],\n",
+    "        description='Image Path Column:',\n",
+    "        disabled=False\n",
+    "    )\n",
+    "    output_labels_widget = ipw.Dropdown(\n",
+    "        options=ds_df.columns,\n",
+    "        value=ds_df.columns[0],\n",
+    "        description='Label Column:',\n",
+    "        disabled=False\n",
+    "    )\n",
+    "    all_dir_list = [p for p, _, _ in os.walk('.') if os.path.isdir(p) and not any([k.startswith('.') and len(k)>1 for k in p.split('/')])]\n",
+    "    base_image_directory_widget = ipw.Select(\n",
+    "        options=all_dir_list,\n",
+    "        value=None,\n",
+    "        rows=5,\n",
+    "        description='Local Image Folder:',\n",
+    "        disabled=False\n",
+    "    )\n",
+    "    def _create_task(btn):\n",
+    "        c_task = make_task(ds_df, \n",
+    "                  image_path = image_path_widget.value,\n",
+    "                  output_labels = output_labels_widget.value,\n",
+    "                  base_image_directory = base_image_directory_widget.value\n",
+    "                 )\n",
+    "        display(FileLink(save_task(c_task)))\n",
+    "    \n",
+    "    create_but = ipw.Button(description='Create Task')\n",
+    "    create_but.on_click(_create_task)\n",
+    "    controls = ipw.VBox([image_path_widget, output_labels_widget,\n",
+    "                                              base_image_directory_widget, create_but])\n",
+    "    out_widget = ipw.HBox([controls,\n",
+    "                           table_viewer])\n",
+    "    display(out_widget)\n",
+    "    return out_widget"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6fce0957bca544a6b1a1cc6c7c3ba3a0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FileUploadWidget(label='Browse', _dom_classes=('widget_item', 'btn-group'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Uploaded `data_summary.csv`\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d6cd2d845c0a4f06ac438d09456f7111",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(VBox(children=(Dropdown(description='Image Path Column:', options=('Unnamed: 0', 'folder', 'Ser…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<a href='task.json' target='_blank'>task.json</a><br>"
+      ],
+      "text/plain": [
+       "/home/jovyan/task.json"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "ds_df = pd.read_csv('sample_data/dataset_overview.csv')"
+    "upload_as_file_widget(_load_csv_app)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
-   "source": [
-    "annotation_task = {\n",
-    "    'google_forms': {'form_url': 'https://docs.google.com/forms/d/e/1FAIpQLSfBmvqCVeDA7IZP2_mw_HZ0OTgDk2a0JN4VlY5KScECWC-_yw/viewform', \n",
-    "    'sheet_url': 'https://docs.google.com/spreadsheets/d/1T02tRhe3IUUHYsMchc7hmH8nVI3uR0GffdX1PNxKIZA/edit?usp=sharing'\n",
-    "            },\n",
-    "    'dataset': {\n",
-    "        'image_path': 'Image Index', # column name\n",
-    "        'output_labels': 'Finding Labels', # column name\n",
-    "        'dataframe': ds_df.to_dict(),\n",
-    "        'base_image_directory': 'sample_data' # path\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "with open('task.json', 'w') as f:\n",
-    "    json.dump(annotation_task, f)"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
install fileupload as a `--user` nbextension to avoid the error messages

here we can also do the experiments for making a GUI for uploading files easily

https://mybinder.org/v2/gh/chestrays/jupyanno/fileupload?urlpath=%2Fmuapps%2Frandom_githubber%2Fanno_app.ipynb

Fixes #10 

## error message
```bash
PermissionError: [Errno 13] Permission denied: '/usr/local/share/jupyter'
Enabling notebook extension fileupload/extension...
      - Validating: problems found:
        - require?  X fileupload/extension
```