### PR TITLE
Change time to total session annotating time

### DIFF
--- a/anno_app.ipynb
+++ b/anno_app.ipynb
@@ -333,6 +333,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "START_TASK_TIME = time()\n",
     "FORM_URL = annotation_task['google_forms']['form_url']\n",
     "anno_questions = get_questions(FORM_URL)\n",
     "\n",
@@ -344,7 +345,7 @@
     "    submit_response(FORM_URL, anno_questions,\n",
     "                    annotator=USERNAME,\n",
     "                    session=HOSTNAME,\n",
-    "                    time=time(),\n",
+    "                    time=time()-START_TASK_TIME,\n",
     "                    item_id=task_result.item_id,\n",
     "                    label=task_result.label,\n",
     "                    task=task_result.task,\n",


### PR DESCRIPTION
the timestamp of the computer is not particularly useful (particularly since we already get a form timestamp from google at the time of submit) so instead we use a session time which would let us see how accuracy changes over the length of an annotation session (maybe?)