### PR TITLE
Removing Deep Learning Junk

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -13,11 +13,11 @@ dependencies:
   - matplotlib
   - pandas
   - bokeh
+  - ipympl
   - SimpleITK
   - scikit-image<=0.20
   - scikit-learn<=0.20
   - nbserverproxy
-  - pymongo
   - pip:
     - plotly
     - pydicom

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,10 +2,8 @@ name: jupyanno
 channels:
   - damianavila82
   - satra
-  - menpo
   - pluraldatum
   - glemaitre
-  - soumith
   - conda-forge
   - defaults
   - simpleitk
@@ -16,18 +14,13 @@ dependencies:
   - pandas
   - bokeh
   - SimpleITK
-  - h5py
   - scikit-image<=0.20
   - scikit-learn<=0.20
-  - pytorch<0.5.0
-  - torchvision
-  - opencv3>=3.0
-  - tensorflow
   - nbserverproxy
   - pymongo
   - pip:
-    - keras<=3.0
     - plotly
+    - pydicom
     - bs4
     - seaborn==0.7.1
     - git+https://github.com/chestrays/multiappmode


### PR DESCRIPTION
cleaning up the dependencies so we can build binder images quicker, I have the feeling we wont need anything fancier than skimage and sklearn for awhile